### PR TITLE
Add a Semigroup instance to HeapT.

### DIFF
--- a/Data/Heap/Internal.hs
+++ b/Data/Heap/Internal.hs
@@ -30,6 +30,7 @@ module Data.Heap.Internal
 import Control.Exception
 import Data.Foldable ( Foldable(foldl, foldr, foldMap), foldl' )
 import Data.List ( groupBy, sortBy )
+import Data.Semigroup
 import Data.Monoid
 import Data.Ord
 import Data.Typeable
@@ -65,6 +66,9 @@ instance (Ord prio, Ord val) => Eq (HeapT prio val) where
 
 instance (Ord prio, Ord val) => Ord (HeapT prio val) where
     compare = comparing toPairAscList
+
+instance (Ord prio) => Semigroup (HeapT prio val) where
+    (<>) = union
 
 instance (Ord prio) => Monoid (HeapT prio val) where
     mempty  = empty

--- a/changes
+++ b/changes
@@ -1,4 +1,8 @@
-Latest version: 1.0.2
+Latest version: 1.0.4
+
+1.0.3 --> 1.0.4
+===============
+- declared needed Semigroup instance for HeapT's Monoid instance
 
 1.0.1 --> 1.0.2
 ===============

--- a/heap.cabal
+++ b/heap.cabal
@@ -1,5 +1,5 @@
 Name:                heap
-Version:             1.0.3
+Version:             1.0.4
 
 Category:            Data Structures
 Synopsis:            Heaps in Haskell


### PR DESCRIPTION
From GHC 8.4 on, `Monoid` instances are required to have a `Semigroup` instance. Since `HeapT` doesn't have one, builds will fail on any GHC 8.4 build or Stackage nightly. I've added one and bumped a minor version. I tested with the `nightly-2018-04-10` Stackage and verified it built correctly.

Please let me know if there's anything else I can do to get this integrated. This fixes #5.