### PR TITLE
tighten base to >= 4.9

### DIFF
--- a/heap.cabal
+++ b/heap.cabal
@@ -23,7 +23,7 @@ Source-Repository head
   Location: git://github.com/3of8/heap.git
 
 Library
-  Build-Depends:     base >= 3 && < 5
+  Build-Depends:     base >= 4.9 && < 5
   Exposed-Modules:
       Data.Heap
   Other-Modules:
@@ -52,7 +52,7 @@ Test-Suite heap-tests
     , Test.Heap.Common
     , Test.Heap.Internal
     , Test.Heap.Item
-  Build-Depends:     base >= 4.6 && < 5, QuickCheck >= 2.10 && < 3
+  Build-Depends:     base >= 4.9 && < 5, QuickCheck >= 2.10 && < 3
   CPP-Options:       -D__TEST__
   GHC-Options:       -Wall -fwarn-tabs -fno-ignore-asserts
   Default-Language:  Haskell2010


### PR DESCRIPTION
Data.Semigroup was added in base 4.9 (https://hackage.haskell.org/package/base-4.9.0.0/docs/Data-Semigroup.html). Compiling this library with earlier versions of base doesn't work.