### PR TITLE
Feature/add bifunctor instance

### DIFF
--- a/Data/Heap/Internal.hs
+++ b/Data/Heap/Internal.hs
@@ -34,6 +34,7 @@ import Data.Semigroup
 import Data.Monoid
 import Data.Ord
 import Data.Typeable
+import Data.Bifunctor
 import Prelude hiding ( foldl, foldr, span, splitAt, foldMap )
 import Text.Read
 
@@ -81,6 +82,15 @@ instance Functor (HeapT prio) where
                         , _left  = fmap f (_left heap)
                         , _right = fmap f (_right heap)
                         }
+
+-- f should be a monotonic function
+instance Bifunctor (HeapT) where
+    bimap _ _ Empty = Empty
+    bimap f g heap = heap { _value = g (_value heap)
+                            , _priority = f (_priority heap)
+                            , _left = bimap f g (_left heap)
+                            , _right = bimap f g (_right heap)
+                          }
 
 instance (Ord prio) => Foldable (HeapT prio) where
     foldMap f = foldMap f . fmap snd . toAscList

--- a/Test/Heap/Common.hs
+++ b/Test/Heap/Common.hs
@@ -9,6 +9,7 @@ module Test.Heap.Common
 
 import Data.Foldable ( Foldable(..) )
 import Data.Monoid
+import Data.Bifunctor
 import Prelude hiding ( foldl, foldr )
 import Test.QuickCheck
 
@@ -48,6 +49,13 @@ monoidProperty m1 m2 m3 = let
 functorProperty :: (Functor f, Eq (f a), Eq (f c)) => (b -> c) -> (a -> b) -> f a -> Bool
 functorProperty f g fun = fun == fmap id fun
     && fmap (f . g) fun == fmap f (fmap g fun)
+
+bifunctorProperty :: (Bifunctor p, Eq(p a d), Eq (p c d), Eq (p c f), Eq (p a f)) => (b -> c) -> (a -> b)
+                                                         -> (e -> f) -> (d -> e) -> p a d -> Bool
+bifunctorProperty f g h i bifun = bifun == bimap id id bifun
+    && bimap (f . g) (h . i) bifun == (bimap f h . bimap g i) bifun
+    && first (f . g) bifun == (first f . first g) bifun
+    && second (h . i) bifun == second h ((second i) bifun)
 
 foldableProperty :: (Foldable f, Eq a) => f a -> Bool
 foldableProperty xs = foldl (flip (:)) [] xs == reverse (foldr (:) [] xs)

--- a/Test/Heap/Common.hs
+++ b/Test/Heap/Common.hs
@@ -4,6 +4,7 @@ module Test.Heap.Common
     , readShowProperty
     , monoidProperty
     , functorProperty
+    , bifunctorProperty
     , foldableProperty
     ) where
 

--- a/Test/Heap/Internal.hs
+++ b/Test/Heap/Internal.hs
@@ -4,6 +4,7 @@ module Test.Heap.Internal
     ) where
 
 import Data.Char
+import Data.Bifunctor
 import Data.Heap.Internal as Heap
 import qualified Data.List as List
 import Test.Heap.Common
@@ -19,6 +20,8 @@ runTests = do
     qc "union" (unionProperty :: HeapT Int Char -> HeapT Int Char -> Bool)
     qc "Functor" (functorProperty (subtract 1000) (*42) :: HeapT Char Int -> Bool)
     qc "fmap" (fmapProperty (subtract 1000) :: HeapT Char Int -> Bool)
+    qc "Bifunctor" (bifunctorProperty toUpper toLower (subtract 1000) (*42) :: HeapT Char Int -> Bool)
+    qc "bimap" (bimapProperty toUpper (subtract 1000) :: HeapT Char Int -> Bool)
     qc "Foldable" (foldableProperty :: HeapT Char Int -> Bool)
     qc "size" sizeProperty
     qc "view" viewProperty
@@ -56,6 +59,9 @@ unionProperty a b = let ab = a `union` b
 
 fmapProperty :: (Ord prio) => (val -> val) -> HeapT prio val -> Bool
 fmapProperty f = leftistHeapProperty . fmap f
+
+bimapProperty :: (Ord prio) => (prio -> prio) -> (val -> val) -> HeapT prio val -> Bool 
+bimapProperty f g = leftistHeapProperty . bimap f g
 
 sizeProperty :: Int -> Bool
 sizeProperty n = let


### PR DESCRIPTION
Adds a Bifunctor instance.

The Bifunctor qc test could probably be better but it passes for now.

I'm not sure if this bimap function should really be a bifunctor instance on HeapT as it requires f to be monotone to prevent the priority ordering from being screwed up. I'm thinking it probably should just be a function called bimapMonotone that explicitly documents the `f should be a monotonic function` requirement.

//Sorry for the driveby PR, I was noodling around with this library and wanted to bimap on it. I'm still a Haskell noob